### PR TITLE
SSH needed for gitlab client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR "${HOME}"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        git-core \
+        git-core openssh-client \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN chown -R "${TEST_USER}:${TEST_USER}" "${HOME}"
 WORKDIR "${HOME}"
 
 RUN apt-get update \
+    && apt-get install --yes --only-upgrade openssl ca-certificates \
     && apt-get install -y --no-install-recommends \
         git-core openssh-client \
     && apt-get clean \


### PR DESCRIPTION
Working on the implementation of a gitlab runner using memote. Pushing back through ssh authentication requires as far as I can see a openssl-client.

Current (not working) implementation:

https://gitlab.com/jjkoehorst/memote-demo2/blob/master/.gitlab-ci.yml